### PR TITLE
adds runGroupBy* functions

### DIFF
--- a/src/main/scala/fs2/interop/cats/cats.scala
+++ b/src/main/scala/fs2/interop/cats/cats.scala
@@ -1,8 +1,11 @@
 package fs2
 package interop
 
+import _root_.cats.Applicative
 import _root_.cats.Monoid
 import _root_.cats.Semigroup
+
+import _root_.cats.std.map.mapMonoid
 
 import fs2.util.Free
 
@@ -23,6 +26,15 @@ package object cats extends Instances {
 
     def runFoldMap[B](f: A => B)(implicit M: Monoid[B]): Free[F, B] =
       self.runFold(M.empty)((b, a) => M.combine(b, f(a)))
+
+    def runGroupByFoldMap[K, B: Monoid](f: A => K)(g: A => B): Free[F, Map[K, B]] =
+      runFoldMap(a => Map(f(a) -> g(a)))
+
+    def runGroupByFoldMonoid[K](f: A => K)(implicit M: Monoid[A]): Free[F, Map[K, A]] =
+      runFoldMap(a => Map(f(a) -> a))
+
+    def runGroupBy[X[_], K](f: A => K)(implicit A: Applicative[X], M: Monoid[X[A]]): Free[F, Map[K, X[A]]] =
+      runGroupByFoldMap(f)(A.pure)
 
   }
 

--- a/src/main/scala/fs2/interop/cats/cats.scala
+++ b/src/main/scala/fs2/interop/cats/cats.scala
@@ -1,7 +1,6 @@
 package fs2
 package interop
 
-import _root_.cats.Applicative
 import _root_.cats.Monoid
 import _root_.cats.Semigroup
 
@@ -33,8 +32,14 @@ package object cats extends Instances {
     def runGroupByFoldMonoid[K](f: A => K)(implicit M: Monoid[A]): Free[F, Map[K, A]] =
       runFoldMap(a => Map(f(a) -> a))
 
-    def runGroupBy[X[_], K](f: A => K)(implicit A: Applicative[X], M: Monoid[X[A]]): Free[F, Map[K, X[A]]] =
-      runGroupByFoldMap(f)(A.pure)
+    def runGroupBy[K](f: A => K)(implicit M: Monoid[A]): Free[F, Map[K, Vector[A]]] = {
+      implicit def vectorMonoid = new Monoid[Vector[A]] {
+        def empty = Vector.empty[A]
+        def combine(a: Vector[A], b: Vector[A]) = a ++ b
+      }
+
+      runGroupByFoldMap(f)(a => Vector(a))
+    }
 
   }
 


### PR DESCRIPTION
- all implemented in terms of `runFoldMap`
- see functional-streams-for-scala/fs2#584 for the reason behind this PR
- I still kept the `Map` type fixed to `collection.immutabe.Map` but maybe this could also be varied later if there is a need for it
