### PR TITLE
[Not ready] Upgrade to cats-0.7.0

### DIFF
--- a/src/main/scala/fs2/interop/cats/Instances.scala
+++ b/src/main/scala/fs2/interop/cats/Instances.scala
@@ -1,20 +1,20 @@
 package fs2.interop.cats
 
 import fs2.util._
-import _root_.cats.{ Eval, Functor => CatsFunctor, Monad => CatsMonad, MonadError }
-import _root_.cats.arrow.NaturalTransformation
+import _root_.cats.{ Functor => CatsFunctor, Monad => CatsMonad, MonadError }
+import _root_.cats.arrow.FunctionK
 
 trait Instances extends Instances0 {
   implicit def effectToMonadError[F[_]](implicit F: Effect[F]): MonadError[F, Throwable] = new MonadError[F, Throwable] {
     def pure[A](a: A) = F.pure(a)
-    override def pureEval[A](a: Eval[A]) = F.delay(a.value)
     override def map[A, B](fa: F[A])(f: A => B) = F.map(fa)(f)
     def flatMap[A, B](fa: F[A])(f: A => F[B]) = F.flatMap(fa)(f)
+    def tailRecM[A, B](a: A)(f: A => F[Either[A,B]]): F[B] = defaultTailRecM(a)(f)
     def raiseError[A](t: Throwable) = F.fail(t)
     def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]) = F.flatMap(F.attempt(fa))(e => e.fold(f, pure))
   }
 
-  implicit def uf1ToNaturalTransformation[F[_], G[_]](implicit uf1: UF1[F, G]): NaturalTransformation[F, G] = new NaturalTransformation[F, G] {
+  implicit def uf1ToFunctionK[F[_], G[_]](implicit uf1: UF1[F, G]): FunctionK[F, G] = new FunctionK[F, G] {
     def apply[A](fa: F[A]) = uf1(fa)
   }
 }
@@ -24,6 +24,7 @@ private[cats] trait Instances0 extends Instances1 {
     def pure[A](a: A) = F.pure(a)
     override def map[A, B](fa: F[A])(f: A => B) = F.map(fa)(f)
     def flatMap[A, B](fa: F[A])(f: A => F[B]) = F.flatMap(fa)(f)
+    def tailRecM[A, B](a: A)(f: A => F[Either[A,B]]): F[B] = defaultTailRecM(a)(f)
     def raiseError[A](t: Throwable) = F.fail(t)
     def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]) = F.flatMap(F.attempt(fa))(e => e.fold(f, pure))
   }
@@ -34,6 +35,7 @@ private[cats] trait Instances1 extends Instances2 {
     def pure[A](a: A) = F.pure(a)
     override def map[A, B](fa: F[A])(f: A => B) = F.map(fa)(f)
     def flatMap[A, B](fa: F[A])(f: A => F[B]) = F.flatMap(fa)(f)
+    def tailRecM[A, B](a: A)(f: A => F[Either[A,B]]): F[B] = defaultTailRecM(a)(f)
   }
 }
 

--- a/src/main/scala/fs2/interop/cats/ReverseInstances.scala
+++ b/src/main/scala/fs2/interop/cats/ReverseInstances.scala
@@ -2,7 +2,7 @@ package fs2.interop.cats
 
 import fs2.util._
 import _root_.cats.{ Functor => CatsFunctor, Monad => CatsMonad, MonadError }
-import _root_.cats.arrow.NaturalTransformation
+import _root_.cats.arrow.FunctionK
 
 trait ReverseInstances extends ReverseInstances0 {
 
@@ -14,8 +14,8 @@ trait ReverseInstances extends ReverseInstances0 {
     def attempt[A](fa: F[A]) = F.handleErrorWith(F.map(fa)(a => Right(a): Either[Throwable, A]))(t => pure(Left(t)))
   }
 
-  implicit def naturalTransformationToUf1[F[_], G[_]](implicit nt: NaturalTransformation[F, G]): UF1[F, G] = new UF1[F, G] {
-    def apply[A](fa: F[A]) = nt(fa)
+  implicit def functionKToUf1[F[_], G[_]](implicit fk: FunctionK[F, G]): UF1[F, G] = new UF1[F, G] {
+    def apply[A](fa: F[A]) = fk(fa)
   }
 }
 

--- a/src/main/scala/fs2/interop/cats/cats.scala
+++ b/src/main/scala/fs2/interop/cats/cats.scala
@@ -4,7 +4,7 @@ package interop
 import _root_.cats.Monoid
 import _root_.cats.Semigroup
 
-import _root_.cats.std.map.mapMonoid
+import _root_.cats.kernel.instances.map.catsKernelStdMonoidForMap
 
 import fs2.util.Catchable
 import fs2.util.Free


### PR DESCRIPTION
This builds off typelevel/cats#1289 so I can test it with fs2.  Submitting early in case anyone finds it useful.  I can finish preparing this when cats-0.7.0 is released.  `tailRecM` may need to change, depending on when 1289 lands.
