### PR TITLE
fix stackoverflow when compiling with scalajs

### DIFF
--- a/shared/src/main/scala/fs2/interop/cats/Instances.scala
+++ b/shared/src/main/scala/fs2/interop/cats/Instances.scala
@@ -61,8 +61,8 @@ private[cats] trait Instances2 {
     def map[A, B](fa: F[A])(f: A => B) = F.map(fa)(f)
   }
 
-  @inline protected def defaultTailRecM[F[_], A, B](a: A)(f: A => F[Either[A,B]])
-                                                   (implicit F: Monad[F]): F[B] =
+  protected def defaultTailRecM[F[_], A, B](a: A)(f: A => F[Either[A,B]])
+                                                 (implicit F: Monad[F]): F[B] =
     F.flatMap(f(a)) {
       case Left(a2) => defaultTailRecM(a2)(f)
       case Right(b) => F.pure(b)


### PR DESCRIPTION
When compiling with scalajs the optimizer crashes with a stackoverflow exception trying to inline `defaultTailRecM`.

```
[error] (client/compile:fullOptJS) scala.collection.parallel.CompositeThrowable: Multiple exceptions thrown during a parallel computation: org.scalajs.core.tools.linke$
.frontend.optimizer.OptimizerCore$OptimizeException: The Scala.js optimizer crashed while optimizing Lfs2_interop_cats_package$.defaultTailRecM__O__F1__Lfs2_util_Monad$
_O: java.lang.StackOverflowError
[error] Methods attempted to inline:
[error] * static Lfs2_interop_cats_Instances2$class.defaultTailRecM__Lfs2_interop_cats_Instances2__O__F1__Lfs2_util_Monad__O
[error] * static s_Function1$class.$$init$__F1__V
[error] * Lfs2_TaskInstancesLowPriority$EffectTask.flatMap__O__F1__O
[error] * Lfs2_TaskInstancesLowPriority$EffectTask.flatMap__Lfs2_Task__F1__Lfs2_Task
[error] * Lfs2_Task.flatMap__F1__Lfs2_Task
[error] * Lfs2_Task.get__Lfs2_internal_Future
[error] * Lfs2_internal_Future.flatMap__F1__Lfs2_internal_Future
[error] * Lfs2_internal_Future$Now.a__O
[error] * s_util_Left.a__O
[error] * Lfs2_interop_cats_package$.defaultTailRecM__O__F1__Lfs2_util_Monad__O
[error]
[error] org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore.optimize(OptimizerCore.scala:154)
[error] org.scalajs.core.tools.linker.frontend.optimizer.GenIncOptimizer$MethodImpl.process(GenIncOptimizer.scala:935)
[error] org.scalajs.core.tools.linker.frontend.optimizer.ParIncOptimizer$$anonfun$processAllTaggedMethods$2.apply(ParIncOptimizer.scala:87)
[error] org.scalajs.core.tools.linker.frontend.optimizer.ParIncOptimizer$$anonfun$processAllTaggedMethods$2.apply(ParIncOptimizer.scala:86)
[error] scala.collection.parallel.mutable.ParArray$ParArrayIterator.foreach_quick(ParArray.scala:145)
[error] scala.collection.parallel.mutable.ParArray$ParArrayIterator.foreach(ParArray.scala:138)
[error] scala.collection.parallel.ParIterableLike$Foreach.leaf(ParIterableLike.scala:975)
[error] scala.collection.parallel.Task$$anonfun$tryLeaf$1.apply$mcV$sp(Tasks.scala:54)
[error] scala.collection.parallel.Task$$anonfun$tryLeaf$1.apply(Tasks.scala:53)
[error] scala.collection.parallel.Task$$anonfun$tryLeaf$1.apply(Tasks.scala:53)
````

When removing the `@inline` annotation everything works fine again.
I think the crash is related to this [issue](https://github.com/scala-js/scala-js/issues/1766) which was marked as wontfix.
