### PR TITLE
Fix implicit conversions for functionK and UF1

### DIFF
--- a/shared/src/main/scala/fs2/interop/cats/Instances.scala
+++ b/shared/src/main/scala/fs2/interop/cats/Instances.scala
@@ -15,7 +15,7 @@ trait Instances extends Instances0 {
     def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]) = F.flatMap(F.attempt(fa))(e => e.fold(f, pure))
   }
 
-  implicit def uf1ToFunctionK[F[_], G[_]](implicit uf1: UF1[F, G]): FunctionK[F, G] = new FunctionK[F, G] {
+  implicit def uf1ToFunctionK[F[_], G[_]](uf1: UF1[F, G]): FunctionK[F, G] = new FunctionK[F, G] {
     def apply[A](fa: F[A]) = uf1(fa)
   }
 

--- a/shared/src/main/scala/fs2/interop/cats/ReverseInstances.scala
+++ b/shared/src/main/scala/fs2/interop/cats/ReverseInstances.scala
@@ -14,7 +14,7 @@ trait ReverseInstances extends ReverseInstances0 {
     def attempt[A](fa: F[A]) = F.handleErrorWith(F.map(fa)(a => Right(a): Either[Throwable, A]))(t => pure(Left(t)))
   }
 
-  implicit def functionKToUf1[F[_], G[_]](implicit fk: FunctionK[F, G]): UF1[F, G] = new UF1[F, G] {
+  implicit def functionKToUf1[F[_], G[_]](fk: FunctionK[F, G]): UF1[F, G] = new UF1[F, G] {
     def apply[A](fa: F[A]) = fk(fa)
   }
 }


### PR DESCRIPTION
Implicit conversions for `FunctionK` and `UF1` were defined to accept an `implicit FunctionK` or an `implicit UF1`. Since these are typically not implicit, it would mean that users would usually have to manually convert them.